### PR TITLE
fix broken image on 404 page

### DIFF
--- a/views/fail.hbs
+++ b/views/fail.hbs
@@ -2,7 +2,7 @@
     <div class="col s12">
         <div class="card-panel">
 		  <div class="row center-align">
-              <img class="responsive-img" src="images/404.jpg" alt="{{{__ "Error!"}}}">
+              <img class="responsive-img" src="/images/404.jpg" alt="{{{__ "Error!"}}}">
 		  </div>
       {{#if error}}
       <div class="row center-align">


### PR DESCRIPTION
 just needed a slash to indicate that we should use the root for images. closes #280